### PR TITLE
Exporting monitoring and logging settings of postgres `aws_db_instance`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,8 @@ resource "aws_db_instance" "instance" {
 
   monitoring_interval = var.monitoring_interval
   monitoring_role_arn = var.monitoring_role_arn
+
+  enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
   
   tags = local.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -61,6 +61,7 @@ resource "aws_db_instance" "instance" {
   apply_immediately   = true
 
   monitoring_interval = var.monitoring_interval
+  monitoring_role_arn = var.monitoring_role_arn
   
   tags = local.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,8 @@ resource "aws_db_instance" "instance" {
   deletion_protection = var.deletion_protection
   apply_immediately   = true
 
+  monitoring_interval = var.monitoring_interval
+  
   tags = local.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -124,3 +124,9 @@ variable "monitoring_role_arn" {
   default     = ""
   type        = string
 }
+
+variable "enable_cloudwatch_logs_exports" {
+  description = "A list of log types to enable for exporting to CloudWatch Logs"
+  default     = []
+  type        = list(string)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -112,3 +112,9 @@ variable "tags" {
   default     = {}
   type        = map(string)
 }
+
+variable "monitoring_interval" {
+  description = "The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. Valid Values: 0, 1, 5, 10, 15, 30, 60."
+  default     = 0
+  type        = number
+}

--- a/variables.tf
+++ b/variables.tf
@@ -125,7 +125,7 @@ variable "monitoring_role_arn" {
   type        = string
 }
 
-variable "enable_cloudwatch_logs_exports" {
+variable "enabled_cloudwatch_logs_exports" {
   description = "A list of log types to enable for exporting to CloudWatch Logs"
   default     = []
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -118,3 +118,9 @@ variable "monitoring_interval" {
   default     = 0
   type        = number
 }
+
+variable "monitoring_role_arn" {
+  description = "The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs."
+  default     = ""
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -126,7 +126,7 @@ variable "monitoring_role_arn" {
 }
 
 variable "enabled_cloudwatch_logs_exports" {
-  description = "A list of log types to enable for exporting to CloudWatch Logs"
+  description = "A list of log types to enable for exporting to CloudWatch Logs. Valid values for postgres are: postgresql and upgrade. See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.Concepts.PostgreSQL.html."
   default     = []
   type        = list(string)
 }


### PR DESCRIPTION
These settings require non-default value by AWS conformance pack `hipaa-security`- `rds-logging-enabled-conformance-pack`. We are exposing them here to be able to set them up using `terraform-aws-rds` module.