### PR TITLE
Add variable that allow to choose CA certificate

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ resource "aws_db_instance" "instance" {
 
   publicly_accessible    = var.publicly_accessible
   vpc_security_group_ids = compact(concat([aws_security_group.sg.id], var.additional_security_group_ids))
-  ca_cert_identifier     = "rds-ca-2019"
+  ca_cert_identifier     = var.ca_cert_identifier
 
   deletion_protection = var.deletion_protection
   apply_immediately   = true

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,12 @@ variable "publicly_accessible" {
   default     = false
 }
 
+variable "ca_cert_identifier" {
+  description = "Identifier of the CA certificate for the DB instance. Example: `rds-ca-2019`, `rds-ca-rsa2048-g1`, `rds-ca-ecc384-g1`, or `rds-ca-rsa4096-g1`."
+  type        = string
+  default     = "rds-ca-2019"
+}
+
 variable "allocated_storage" {
   description = "The size of the attached disk in GB"
   type        = number


### PR DESCRIPTION
This module allows us to use only `rds-ca-2019`, which expires on August 22, 2024. I added a variable called `ca_cert_identifier` that allows you to choose which CA certificate you want to use. By default, I use the value `rds-ca-2019`, that is why no changes should be done from clients. Only if clients want to change their CA Certificate they are able to do it.
