### PR TITLE
Set a valid CA certificate identifier as the default value

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -54,9 +54,9 @@ variable "publicly_accessible" {
 }
 
 variable "ca_cert_identifier" {
-  description = "Identifier of the CA certificate for the DB instance. Example: `rds-ca-2019`, `rds-ca-rsa2048-g1`, `rds-ca-ecc384-g1`, or `rds-ca-rsa4096-g1`."
+  description = "Identifier of the CA certificate for the DB instance. Example: `rds-ca-rsa2048-g1`, `rds-ca-ecc384-g1`, or `rds-ca-rsa4096-g1`."
   type        = string
-  default     = "rds-ca-2019"
+  default     = "rds-ca-rsa2048-g1"
 }
 
 variable "allocated_storage" {


### PR DESCRIPTION
> Amazon RDS Certificate Authority certificates rds-ca-2019 expired in August, 2024.
[ref](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL-certificate-rotation.html)

This PR contains the changes to have a valid CA certificate identifier as the default value.